### PR TITLE
Add virtual try-on SaaS prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+node_modules/

--- a/readme.md
+++ b/readme.md
@@ -105,3 +105,8 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 ## Contact
 For questions or support, please email support@calm-ai.example.com
+
+---
+
+## Virtual Try-On SaaS Prototype
+This repository also contains a proof-of-concept for a virtual try-on widget for e-commerce stores. See `virtual-tryon/README.md` for details.

--- a/virtual-tryon/README.md
+++ b/virtual-tryon/README.md
@@ -1,0 +1,46 @@
+# Virtual Try-On SaaS
+
+This directory contains a minimal prototype for a virtual try-on service that can be embedded into e-commerce stores. It consists of:
+
+- `backend/` – FastAPI service for processing selfie uploads and generating personalized videos.
+- `widget/` – React component that stores can embed on product pages.
+- `admin-dashboard/` – Skeleton React app for brands to manage settings and view analytics.
+
+## Running Locally
+
+1. **Backend**
+   ```bash
+   cd backend
+   pip install -r requirements.txt
+   uvicorn main:app --reload
+   ```
+   The API will be available at `http://localhost:8000`.
+
+2. **Widget**
+   Bundle the React component using your choice of build tool (e.g., webpack or Vite). The bundled script can then be included on a store's page as shown in `widget/README.md`.
+
+3. **Admin Dashboard**
+   ```bash
+   cd admin-dashboard
+   npm install
+   npm start
+   ```
+
+## Embedding Example
+
+Include the compiled widget script and render the component:
+
+```html
+<div id="tryon"></div>
+<script src="/static/TryOnWidget.js"></script>
+<script>
+  ReactDOM.render(
+    React.createElement(TryOnWidget, { productId: 'shirt123', apiUrl: 'http://localhost:8000' }),
+    document.getElementById('tryon')
+  );
+</script>
+```
+
+## Notes
+- Replace the mocked AI API call in `backend/main.py` with a real call to HeyGen or RunwayML using your API key.
+- Store uploaded files and generated videos on a persistent storage service like AWS S3 in production.

--- a/virtual-tryon/admin-dashboard/README.md
+++ b/virtual-tryon/admin-dashboard/README.md
@@ -1,0 +1,19 @@
+# Admin Dashboard (Skeleton)
+
+This directory contains a minimal React-based admin dashboard for e-commerce brands to manage the try-on widget.
+
+Suggested setup uses [Create React App](https://create-react-app.dev/). Run the following commands to bootstrap:
+
+```bash
+npx create-react-app admin-dashboard
+cd admin-dashboard
+npm start
+```
+
+Basic pages to implement:
+- **Login** – simple auth (replace with real authentication)
+- **Analytics** – display number of generated videos, engagement stats
+- **Product Management** – CRUD interface for product demo videos
+- **Settings** – widget customization options
+
+The dashboard should communicate with the FastAPI backend for analytics and product management APIs.

--- a/virtual-tryon/admin-dashboard/package.json
+++ b/virtual-tryon/admin-dashboard/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "admin-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  }
+}

--- a/virtual-tryon/admin-dashboard/src/App.js
+++ b/virtual-tryon/admin-dashboard/src/App.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function App() {
+  return (
+    <div>
+      <h1>Virtual Try-On Admin Dashboard</h1>
+      <p>Login and analytics will appear here.</p>
+    </div>
+  );
+}
+
+export default App;

--- a/virtual-tryon/backend/Dockerfile
+++ b/virtual-tryon/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.9-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/virtual-tryon/backend/README.md
+++ b/virtual-tryon/backend/README.md
@@ -1,0 +1,31 @@
+# Virtual Try-On Backend
+
+This FastAPI service exposes an endpoint for receiving user selfies and product information. It then calls an external AI API to generate a personalized product video.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the server:
+
+```bash
+uvicorn main:app --reload
+```
+
+3. Environment variables for external API keys (e.g., `HEYGEN_API_KEY`) should be defined in a `.env` file or environment.
+
+## Endpoint
+
+`POST /api/try-on`
+
+Form fields:
+- `product_id` – ID or slug of the product/video.
+- `file` – uploaded image of the user.
+
+Returns JSON containing a `video_url` pointing to the generated video.
+
+The current implementation mocks the AI API call by copying a sample video. Replace the section marked `TODO` in `main.py` with real API calls to HeyGen or RunwayML.

--- a/virtual-tryon/backend/main.py
+++ b/virtual-tryon/backend/main.py
@@ -1,0 +1,49 @@
+from fastapi import FastAPI, File, UploadFile, HTTPException, Form
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+import os
+import shutil
+import uuid
+
+app = FastAPI(title="Virtual Try-On API")
+
+# Allow widget to call API from e-commerce sites
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # replace with specific domains in production
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+UPLOAD_DIR = "uploads"
+VIDEO_DIR = "videos"
+os.makedirs(UPLOAD_DIR, exist_ok=True)
+os.makedirs(VIDEO_DIR, exist_ok=True)
+
+class TryOnResponse(BaseModel):
+    video_url: str
+
+@app.post("/api/try-on", response_model=TryOnResponse)
+async def try_on(product_id: str = Form(...), file: UploadFile = File(...)):
+    """Receive selfie and product info, call AI API, and return video URL."""
+    # Save selfie locally
+    selfie_id = str(uuid.uuid4())
+    selfie_path = os.path.join(UPLOAD_DIR, f"{selfie_id}_{file.filename}")
+    with open(selfie_path, "wb") as buffer:
+        shutil.copyfileobj(file.file, buffer)
+
+    try:
+        # TODO: Replace with call to external AI service (HeyGen/RunwayML)
+        # For demonstration, copy a sample video to simulate processing
+        sample_video = os.path.join("static", "sample.mp4")
+        generated_video = os.path.join(VIDEO_DIR, f"{selfie_id}.mp4")
+        shutil.copyfile(sample_video, generated_video)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="AI processing failed")
+
+    return {"video_url": f"/videos/{selfie_id}.mp4"}
+
+app.mount("/videos", StaticFiles(directory=VIDEO_DIR), name="videos")
+app.mount("/static", StaticFiles(directory="static"), name="static")

--- a/virtual-tryon/backend/requirements.txt
+++ b/virtual-tryon/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+python-multipart
+pydantic

--- a/virtual-tryon/backend/static/sample.mp4
+++ b/virtual-tryon/backend/static/sample.mp4
@@ -1,0 +1,1 @@
+sample video placeholder

--- a/virtual-tryon/widget/README.md
+++ b/virtual-tryon/widget/README.md
@@ -1,0 +1,18 @@
+# Try-On Widget
+
+React component to embed on e-commerce product pages. Allows customers to upload a selfie and view a personalized product video.
+
+Usage example:
+
+```html
+<div id="tryon"></div>
+<script src="/path/to/bundle.js"></script>
+<script>
+  ReactDOM.render(
+    React.createElement(TryOnWidget, { productId: 'shirt123', apiUrl: 'http://localhost:8000' }),
+    document.getElementById('tryon')
+  );
+</script>
+```
+
+Bundle this component using your preferred tool (e.g., webpack or Vite) and expose it globally for easy embedding.

--- a/virtual-tryon/widget/TryOnWidget.jsx
+++ b/virtual-tryon/widget/TryOnWidget.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+
+export default function TryOnWidget({ productId, apiUrl }) {
+  const [videoUrl, setVideoUrl] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleFileChange = async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('product_id', productId);
+    formData.append('file', file);
+    setLoading(true);
+
+    try {
+      const res = await fetch(`${apiUrl}/api/try-on`, {
+        method: 'POST',
+        body: formData,
+      });
+      const data = await res.json();
+      setVideoUrl(`${apiUrl}${data.video_url}`);
+    } catch (err) {
+      console.error('Upload failed', err);
+      alert('Something went wrong.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="tryon-widget">
+      {videoUrl ? (
+        <video src={videoUrl} controls autoPlay width="300" />
+      ) : (
+        <>
+          <input
+            type="file"
+            accept="image/*"
+            onChange={handleFileChange}
+            style={{ display: 'none' }}
+            id="tryon-input"
+          />
+          <label htmlFor="tryon-input" className="tryon-button">
+            {loading ? 'Processing...' : 'Try with your face'}
+          </label>
+        </>
+      )}
+    </div>
+  );
+}

--- a/virtual-tryon/widget/index.js
+++ b/virtual-tryon/widget/index.js
@@ -1,0 +1,2 @@
+import TryOnWidget from './TryOnWidget';
+export default TryOnWidget;


### PR DESCRIPTION
## Summary
- build `virtual-tryon` proof‑of‑concept with FastAPI backend, React widget, and admin dashboard skeleton
- include Dockerfile and requirements
- add documentation for backend, widget, admin dashboard
- link new project from root README
- add .gitignore

## Testing
- `python -m py_compile virtual-tryon/backend/main.py`
- `npm install --package-lock-only` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688142e0cfac8325b95e408b029d3ca7